### PR TITLE
Add room impulse response with noise

### DIFF
--- a/pyfar.signals.files/room_impulse_response_with_noise.wav
+++ b/pyfar.signals.files/room_impulse_response_with_noise.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c6b1371139eb56c8dbc3b94337bdd5737cd749d7dd0b925edab0cd87c0846d12
+size 240046


### PR DESCRIPTION
This is a version of `pyfar.signals.files.room_impulse_response()` that still has the nois tail. I would like to add this for being used in a new pyrato example notebook showing how to estimate room acoustic parameters.

In a second step I would make a pull in pyfar to add a boolen parameter to `pyfar.signals.files.room_impulse_response()` to indicate wether or not to return the RIR with noise tail.

I thought about also adding the Matlab script for generating the data using the raw measurement. But that requires private files anyhow. So I opted to not do this.