### PR TITLE
Upload 32 bit versions of the RIR

### DIFF
--- a/pyfar.signals.files/room_impulse_response.wav
+++ b/pyfar.signals.files/room_impulse_response.wav
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a68e866025230f0323937c82c1d4280143fefc8ceddddc743b3a7178bfaab41e
-size 168396
+oid sha256:39e82228d38b5b7067e79a638864b08fd5421ff8a5715e413c3f4accb06dc8e6
+size 336784

--- a/pyfar.signals.files/room_impulse_response_with_noise.wav
+++ b/pyfar.signals.files/room_impulse_response_with_noise.wav
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c6b1371139eb56c8dbc3b94337bdd5737cd749d7dd0b925edab0cd87c0846d12
-size 240046
+oid sha256:e9ba011746851d4cdeefb267755561fbccf03e824e9a75d6063061f6d7631523
+size 480084


### PR DESCRIPTION
We stored 16 Bit wave files previously and one could see the quantization in the noise tail. This is now solved. I compared the old and new versions offline to make sure they have the same level and length.
Replaced with 32 bit integer wav file.